### PR TITLE
DHCPクライアント機能を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 PROGRAM = echo_server
 
-OBJECTS = microps.o tcp.o udp.o icmp.o ip.o arp.o ethernet.o util.o
+OBJECTS = microps.o tcp.o udp.o icmp.o ip.o arp.o ethernet.o util.o dhcp.o
 
 CFLAGS  := $(CFLAGS) -g -W -Wall -Wno-unused-parameter 
 
 ifeq ($(shell uname),Linux)
 	OBJECTS := $(OBJECTS) pkt.o
-	CFLAGS  := $(CFLAGS) -lpthread
+	CFLAGS  := $(CFLAGS) -lpthread -pthread
 endif
 
 ifeq ($(shell uname),Darwin)

--- a/dhcp.c
+++ b/dhcp.c
@@ -1,8 +1,19 @@
 #include <stdio.h>
 #include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 #include "ethernet.h"
 #include "ip.h"
+#include "udp.h"
 #include "util.h"
+
+#define DHCP_MESSAGE_MIN_LEN (sizeof(struct dhcp) + 64)
+#define DHCP_MESSAGE_BUF_LEN (sizeof(struct dhcp) + 312)
+#define DHCP_MAGIC_CODE "\x63\x82\x53\x63"
+#define DHCP_FLAG_BROADCAST (0x8000)
+#define DHCP_VENDOR_BYTE_SIZE 64
+#define DHCP_CLIENT_PORT 68
+#define DHCP_SERVER_PORT 67
 
 struct dhcp {
     uint8_t op;
@@ -21,11 +32,6 @@ struct dhcp {
     uint8_t file[128];
     uint8_t options[0];
 };
-
-#define DHCP_MESSAGE_MIN_LEN (sizeof(struct dhcp) + 64)
-#define DHCP_MESSAGE_BUF_LEN (sizeof(struct dhcp) + 312)
-#define DHCP_MAGIC_CODE "\x63\x82\x53\x63"
-#define DHPC_FLAG_BROADCAST (0x8000)
 
 void
 dhcp_debug_message(const struct dhcp *p, size_t n) {
@@ -62,6 +68,275 @@ dhcp_debug_message(const struct dhcp *p, size_t n) {
         }
         fprintf(stderr, "\n");
     }
-    fprintf(stderr, "option[%02x]\n", *opt++);
+    fprintf(stderr, "option:[%02x]\n", *opt++);
     fprintf(stderr, "total %d bytes (padding %d bytes)\n", n, n - (opt - (uint8_t *)p));
+}
+
+static void
+dhcp_build_discover(struct dhcp *discover, ethernet_addr_t eth, uint32_t xid) {
+    uint8_t *opt;    
+
+    // add discover packet info    
+    discover->op = 0x01;
+    discover->htype = 0x01;
+    discover->hlen = 0x06;
+    discover->xid = hton32(xid);
+    discover->flags = hton16(DHCP_FLAG_BROADCAST);
+    memcpy(discover->chaddr, eth.addr, 6);
+
+    // add dhcp vendor info
+    opt = discover->options;
+    // MAGIC
+    memcpy(opt, DHCP_MAGIC_CODE, 4);
+    opt += 4;
+    // discover
+    *opt++ = 0x35;
+    *opt++ = 0x01;
+    *opt++ = 0x01;
+    // client ID
+    *opt++ = 0x3D;
+    *opt++ = 0x07;
+    *opt++ = 0x01;
+    // MAC addr
+    memcpy(opt, discover->chaddr, 6);
+    opt += 6;
+    // Stopper
+    *opt++ = 0xFF;
+}
+
+static void
+dhcp_build_request(struct dhcp *request, ethernet_addr_t eth, uint32_t yiaddr, uint32_t siaddr, uint32_t xid) {
+    uint8_t *opt;    
+
+    request->op = 0x01;
+    request->htype = 0x01;
+    request->hlen = 0x06;
+    request->xid = hton32(xid);
+    request->flags = hton16(DHCP_FLAG_BROADCAST);
+    request->yiaddr = yiaddr;
+    request->siaddr = siaddr;
+    memcpy(request->chaddr, eth.addr, 6);
+
+    // vender part
+    opt = request->options;
+    memcpy(opt, DHCP_MAGIC_CODE, 4);
+    opt += 4;
+    // request
+    *opt++ = 0x35;
+    *opt++ = 0x01;
+    *opt++ = 0x03;
+    // client id
+    *opt++ = 0x3D;
+    *opt++ = 0x07;
+    *opt++ = 0x01;
+    // MAC addr
+    memcpy(opt, request->chaddr, 6);
+    opt += 6;
+    // request ip
+    *opt++ = 0x32;
+    *opt++ = 0x04;
+    // user ip addr
+    memcpy(opt, &request->yiaddr, 4);
+    opt += 4;
+    // stopper
+    *opt++ = 0xFF;
+}
+
+static void
+dhcp_get_addr_fromack(struct dhcp *ack, uint32_t *addr, uint32_t *netmask, uint32_t *gateway) {
+    size_t len;
+    uint8_t *options = ack->options;
+    uint8_t opt_type;
+    
+    *addr = ack->yiaddr;
+    // skip magic
+    options += 4;
+
+    while(*options != 0xFF){
+        opt_type = *options++;
+        len = *options++;
+        switch(opt_type){
+            case 0x01:
+                *netmask = *(uint32_t *)options;
+                break;
+            case 0x03:
+                *gateway = *(uint32_t *)options;
+                break;
+            default:
+                break;
+        }
+        options += len;
+    }
+}
+
+static int 
+dhcp_recv_message(int sock, uint8_t *buf, size_t size, uint32_t xid, uint8_t *type) {
+    int len;
+    struct dhcp *msg;
+    uint8_t *opt;
+    
+    while (1) {
+        len = udp_api_recvfrom(sock, buf, size, NULL, NULL);
+        if (len < DHCP_MESSAGE_MIN_LEN) {
+            continue;
+        }
+        msg = (struct dhcp *)buf;
+        if (msg->op != 0x02){
+            continue;
+        }
+        if (msg->xid != hton32(xid)) {
+            continue;
+        }
+        opt = msg->options;
+        if (memcmp((uint32_t *)opt, DHCP_MAGIC_CODE, 4)) {
+             continue;
+        }
+        opt += 4;
+        while (*opt != 0xff) {
+            if (*opt++ != 0x35) {
+                opt += *opt;
+                continue;
+            }
+            if (*opt++ != 0x01) {
+                fprintf(stderr, "WARNING: Option 0x35 length is not one.\n");
+            }
+            break;
+        }
+        if (*type == 0) {
+            *type = *opt;
+        }
+        if (*opt != *type) {
+            continue;
+        }
+        break;
+    }
+    return len;
+}
+
+int
+dhcp_init(char *ethernet_addr) { 
+    int res, sock, len;
+    uint8_t *opt, kind;
+    uint8_t sbuf[DHCP_MESSAGE_MIN_LEN];
+    uint8_t rbuf[DHCP_MESSAGE_BUF_LEN];
+    uint32_t yiaddr, siaddr, nmaddr, gwaddr;
+    uint32_t xid = (uint32_t)time(NULL);
+    struct dhcp *discover, *offer, *request, *ack;
+    char addr[IP_ADDR_STR_LEN+1],netmask[IP_ADDR_STR_LEN+1], gateway[IP_ADDR_STR_LEN+1];
+    ethernet_addr_t eth_addr;
+    ip_addr_t peer;
+    uint16_t peer_port = hton16(DHCP_SERVER_PORT);
+    
+    sock = udp_api_open();
+    if (sock < 0) {
+        fprintf(stderr, "udp sock open failed.\n");
+        goto ERROR;
+    }
+
+    res = udp_api_bind(sock, hton16(DHCP_CLIENT_PORT));
+    if (res < 0) {
+        fprintf(stderr, "udp sock bind failed.\n");
+        goto ERROR;
+    }
+    
+    ethernet_addr_pton(ethernet_addr, &eth_addr);
+    peer = IP_ADDR_BCAST;
+
+    memset(sbuf, 0x00, sizeof(sbuf));
+    discover = (struct dhcp *)sbuf;
+    dhcp_build_discover(discover, eth_addr, xid);
+#ifdef DEBUG
+    dhcp_debug_message(discover, sizeof(sbuf));
+#endif
+
+    // send discover
+    len = udp_api_sendto(sock, sbuf, sizeof(sbuf), &peer, peer_port);  
+    if (len < 0) {
+        goto ERROR;
+    }
+
+    kind = 0x02;
+    len = dhcp_recv_message(sock, rbuf, sizeof(rbuf), xid, &kind);
+
+    
+    offer = (struct dhcp *)rbuf;
+#ifdef DEBUG
+    dhcp_debug_message(offer, len);
+#endif
+
+    // get yi addr and si addr
+    yiaddr = offer->yiaddr;
+    siaddr = offer->siaddr;
+
+    // build request packet
+    memset(sbuf, 0x00, sizeof(sbuf));
+    request = (struct dhcp *)sbuf;
+    dhcp_build_request(request, eth_addr, yiaddr, siaddr, xid);
+#ifdef DEBUG
+    dhcp_debug_message(request, sizeof(sbuf));
+#endif
+
+    // send request packet
+    len = udp_api_sendto(sock, sbuf, sizeof(sbuf), &peer, peer_port);
+    if (len < 0) {
+        goto ERROR;
+    }
+
+    // recv ack packet
+    kind = 0;
+    len = dhcp_recv_message(sock, rbuf, sizeof(rbuf), xid, &kind);
+
+    if (kind != 0x05) {
+        goto ERROR;
+    }
+
+    ack = (struct dhcp *)rbuf;
+#ifdef DEBUG
+    dhcp_debug_message(ack, len);
+#endif 
+   
+    udp_api_close(sock);
+
+
+    //get default-gateway and subnet-mask
+    uint8_t *options = ack->options;
+    //drop MAGIC
+    options += 4;    
+
+    size_t len;
+    uint8_t opt_type;
+    uint32_t *sbaddr;
+    uint32_t *gwaddr;
+    //0xFF is stopper
+    while(*options != 0xFF){
+        opt_type = *options++;
+        len = *options++;
+        switch(opt_type){
+            //get subnet mask
+            case 0x01:
+                sbaddr = (uint32_t *)options;
+                break;
+            //get default gateway
+            case 0x03:
+                gwaddr = (uint32_t *)options;
+                break;
+            default:
+                break;
+        }
+        options += len;
+    }
+ 
+    
+    dhcp_get_addr_fromack(ack, &yiaddr, &nmaddr, &gwaddr);
+
+    ip_addr_ntop(&yiaddr, addr, sizeof(addr));
+    ip_addr_ntop(&nmaddr, netmask, sizeof(netmask)); 
+    ip_addr_ntop(&gwaddr, gateway, sizeof(gateway));
+    ip_init(addr, netmask, gateway, 1); 
+    return 0;
+ERROR:  
+    if (sock != -1) {
+        udp_api_close(sock);
+    }
+    return -1;
 }

--- a/dhcp.c
+++ b/dhcp.c
@@ -297,35 +297,6 @@ dhcp_init(char *ethernet_addr) {
    
     udp_api_close(sock);
 
-
-    //get default-gateway and subnet-mask
-    uint8_t *options = ack->options;
-    //drop MAGIC
-    options += 4;    
-
-    size_t len;
-    uint8_t opt_type;
-    uint32_t *sbaddr;
-    uint32_t *gwaddr;
-    //0xFF is stopper
-    while(*options != 0xFF){
-        opt_type = *options++;
-        len = *options++;
-        switch(opt_type){
-            //get subnet mask
-            case 0x01:
-                sbaddr = (uint32_t *)options;
-                break;
-            //get default gateway
-            case 0x03:
-                gwaddr = (uint32_t *)options;
-                break;
-            default:
-                break;
-        }
-        options += len;
-    }
- 
     
     dhcp_get_addr_fromack(ack, &yiaddr, &nmaddr, &gwaddr);
 

--- a/dhcp.h
+++ b/dhcp.h
@@ -1,0 +1,7 @@
+#ifndef _DHCP_H_
+#define _DHCP_H_
+
+extern int
+dhcp_init (char *);
+
+#endif

--- a/echo_server.c
+++ b/echo_server.c
@@ -15,11 +15,12 @@ struct microps_param param = {
 };
 */
 struct microps_param param = {
-    .ethernet_device = "en0",
-    .ethernet_addr = "58:55:ca:fb:6e:9f",
-    .ip_addr = "10.13.100.100",
-    .ip_netmask = "255.255.0.0",
-    .ip_gateway = "10.13.0.1"
+    .ethernet_device = "enp0s8",
+    .ethernet_addr = "08:00:27:0c:a1:27",
+    .ip_addr = "0.0.0.0",
+    .ip_netmask = "0.0.0.0",
+    .ip_gateway = NULL,
+    .use_dhcp = 1
 };
 
 int

--- a/ip.h
+++ b/ip.h
@@ -33,6 +33,6 @@ ip_add_protocol (uint8_t protocol, __ip_protocol_handler_t handler);
 extern ssize_t
 ip_output (uint8_t protocol, const uint8_t *buf, size_t len, const ip_addr_t *addr);
 extern int
-ip_init (const char *addr, const char *netmask, const char *gateway);
+ip_init (const char *addr, const char *netmask, const char *gateway, uint8_t reconfigure);
 
 #endif

--- a/microps.c
+++ b/microps.c
@@ -13,7 +13,7 @@ microps_init (const struct microps_param *param) {
     if (arp_init() == -1) {
         goto ERROR;
     }
-    if (ip_init(param->ip_addr, param->ip_netmask, param->ip_gateway) == -1) {
+    if (ip_init(param->ip_addr, param->ip_netmask, param->ip_gateway, 0) == -1) {
         goto ERROR;
     }
     if (icmp_init() == -1) {
@@ -27,6 +27,11 @@ microps_init (const struct microps_param *param) {
     }
     if (ethernet_device_run() == -1) {
         goto ERROR;
+    }
+    if (param->use_dhcp) {
+        if (dhcp_init(param->ethernet_addr) == -1) {
+	        goto ERROR;
+        }
     }
     return  0;
 ERROR:

--- a/microps.h
+++ b/microps.h
@@ -8,6 +8,7 @@
 #include "icmp.h"
 #include "udp.h"
 #include "tcp.h"
+#include "dhcp.h"
 
 struct microps_param {
     char *ethernet_device;
@@ -15,6 +16,7 @@ struct microps_param {
     char *ip_addr;
     char *ip_netmask;
     char *ip_gateway;
+    uint8_t use_dhcp;
 };
 
 extern int

--- a/udp.c
+++ b/udp.c
@@ -196,8 +196,12 @@ udp_api_recvfrom (int soc, uint8_t *buf, size_t size, ip_addr_t *peer, uint16_t 
     }
     pthread_mutex_unlock(&udp.cb.mutex);
     queue_hdr = (struct udp_queue_hdr *)entry->data;
-    *peer = queue_hdr->addr;
-    *port = queue_hdr->port;
+    if (peer) {
+        *peer = queue_hdr->addr;
+    }
+    if (port) {
+        *port = queue_hdr->port;
+    }
     len = MIN(size, queue_hdr->len);
     memcpy(buf, queue_hdr + 1, len);
     free(entry->data);


### PR DESCRIPTION
# 概要

DHCPクライアント機能を追加し、それにより動的にIP設定を行えるようになりました。

# 変更点

- struct microps_param にDHCPの利用に関するフラグを追加
- ip_init() 関数に再設定に関するフラグを追加
    - 再設定時にIPルーティングテーブルの初期化をする必要があるため
    - ethernet_add_protocol() 関数による二重登録を防ぐため

# 使用方法・設定等

```c
struct microps_param param = {
    .ethernet_device = "enp0s8",
    .ethernet_addr = "08:00:27:0c:a1:27",
    .ip_addr = "0.0.0.0",
    .ip_netmask = "0.0.0.0",
    .ip_gateway = NULL,
    .use_dhcp = 1
};
```

DHCPクライアント機能は、上記のように use_dhcp パラメータに1を設定することで利用できる。
このプルリクエストの変更において echo_server.c 内で実際にこの設定を適用しています。

# 動作・ログ

以下が実際にプロトコルスタックをビルドしechoサーバとして使用した場合のデバッグログになります。
```
0.0.0.0, 0.0.0.0, (null)
========== DHCP Message Debug Print ==========
    op: 1
 htype: 1
  hlen: 6
  hops: 0
   xid: 5abda168 (1522377064)
  secs: 0
 flags: 8000
ciaddr: 0.0.0.0
yiaddr: 0.0.0.0
siaddr: 0.0.0.0
giaddr: 0.0.0.0
chaddr: 08:00:27:0c:a1:27
 sname: 
  file: 
 magic: 63 53 82 63
option[35] 01
option[3d] 01 08 00 27 0c a1 27
option:[ff]
total 300 bytes (padding 47 bytes)
========== DHCP Message Debug Print ==========
    op: 2
 htype: 1
  hlen: 6
  hops: 0
   xid: 5abda168 (1522377064)
  secs: 0
 flags: 8000
ciaddr: 0.0.0.0
yiaddr: 192.168.0.102
siaddr: 192.168.0.1
giaddr: 0.0.0.0
chaddr: 08:00:27:0c:a1:27
 sname: 
  file: 
 magic: 63 53 82 63
option[35] 02
option[36] c0 a8 00 01
option[33] 00 00 02 58
option[01] ff ff ff 00
option[03] c0 a8 00 01
option[06] c0 a8 00 01
option[0f] 55 62 75 6e 74 75 53 65 72 76 65 72 44 48 43 50 53 65 72 76 65 72 2e 6c 6f 63 61 6c
option:[ff]
total 304 bytes (padding 0 bytes)
========== DHCP Message Debug Print ==========
    op: 1
 htype: 1
  hlen: 6
  hops: 0
   xid: 5abda168 (1522377064)
  secs: 0
 flags: 8000
ciaddr: 0.0.0.0
yiaddr: 192.168.0.102
siaddr: 192.168.0.1
giaddr: 0.0.0.0
chaddr: 08:00:27:0c:a1:27
 sname: 
  file: 
 magic: 63 53 82 63
option[35] 03
option[3d] 01 08 00 27 0c a1 27
option[32] c0 a8 00 66
option:[ff]
total 300 bytes (padding 41 bytes)
========== DHCP Message Debug Print ==========
    op: 2
 htype: 1
  hlen: 6
  hops: 0
   xid: 5abda168 (1522377064)
  secs: 0
 flags: 8000
ciaddr: 0.0.0.0
yiaddr: 192.168.0.102
siaddr: 192.168.0.1
giaddr: 0.0.0.0
chaddr: 08:00:27:0c:a1:27
 sname: 
  file: 
 magic: 63 53 82 63
option[35] 05
option[36] c0 a8 00 01
option[33] 00 00 02 58
option[01] ff ff ff 00
option[03] c0 a8 00 01
option[06] c0 a8 00 01
option[0f] 55 62 75 6e 74 75 53 65 72 76 65 72 44 48 43 50 53 65 72 76 65 72 2e 6c 6f 63 61 6c
option:[ff]
total 304 bytes (padding 0 bytes)
192.168.0.102, 255.255.255.0, 192.168.0.1
accept success, soc=0, acc=1
+------+-------------------------------------------------+------------------+
| 0000 | 68 65 6c 6c 6f 0d 0a                            | hello..          |
+------+-------------------------------------------------+------------------+
+------+-------------------------------------------------+------------------+
| 0000 | 48 65 6c 6c 6f 2c 57 6f 72 6c 64 21 21 0d 0a    | Hello,World!!..  |
+------+-------------------------------------------------+------------------+
```

確認お願いします。