### PR TITLE
fix the conflicting types

### DIFF
--- a/pkt.c
+++ b/pkt.c
@@ -69,7 +69,7 @@ device_close (device_t *device) {
 }
 
 void
-device_input (device_t *device, void (*callback)(uint8_t *, size_t), int timeout) {
+device_input (device_t *device, void (*callback)(uint8_t *, size_t, void *), void *args, int timeout) {
     struct pollfd pfd;
     ssize_t ret, length;
     uint8_t buffer[2048];


### PR DESCRIPTION
For now, it occurs the following error.
```
pkt.c:72:1: error: conflicting types for ‘device_input’
 device_input (device_t *device, void (*callback)(uint8_t *, size_t), int timeout) {
 ^~~~~~~~~~~~
In file included from pkt.c:12:
device.h:13:1: note: previous declaration of ‘device_input’ was here
 device_input (device_t *device, void (*callback)(uint8_t *, size_t, void *), void *, int timeout);
 ^~~~~~~~~~~~
pkt.c: In function ‘device_input’:
pkt.c:87:5: error: too many arguments to function ‘callback’
     callback(buffer, length, device);
     ^~~~~~~~
```

I found the `device_input` is declared in [device.h](https://github.com/pandax381/microps/blob/master/device.h#L13) but [the usage in pkt.c](https://github.com/pandax381/microps/blob/master/pkt.c#L72) doesn't match it.

Apply this patch can fix the issue. 