### PR TITLE
Fix bug : util mask functions index handling

### DIFF
--- a/util.c
+++ b/util.c
@@ -198,7 +198,7 @@ maskset (uint32_t *mask, size_t size, size_t offset, size_t len) {
     for (idx = so; idx < so + (len / 32); idx++) {
         mask[idx + 1] = 0xffffffff;
     }
-    len -= (32 * idx);
+    len -= (32 * (idx - so));
     if (len) {
         mask[idx + 1] |= (0xffffffff >> (32 - len));
     }
@@ -220,7 +220,7 @@ maskchk (uint32_t *mask, size_t size, size_t offset, size_t len) {
             return 0;
         }
     }
-    len -= (32 * idx);
+    len -= (32 * (idx - so));
     if (len) {
         if ((mask[idx + 1] & (0xffffffff >> (32 - len))) ^ (0xffffffff >> (32 - len))) {
             return 0;


### PR DESCRIPTION
mask の処理にバグがあったので修正しました。
`idx` は最終的なインデックスであり、どれだけ進んだかを表すためには `idx` から初期値である `so` を引く必要があります。