### PR TITLE
Fix tcp_incoming_event function in SYN-RECEIVED state

### DIFF
--- a/tcp.c
+++ b/tcp.c
@@ -308,12 +308,12 @@ tcp_incoming_event (struct tcp_cb *cb, struct tcp_hdr *hdr, size_t len) {
         case TCP_CB_STATE_SYN_RCVD:
             if (cb->snd.una <= ntoh32(hdr->ack) && ntoh32(hdr->ack) <= cb->snd.nxt) {
                 cb->state = TCP_CB_STATE_ESTABLISHED;
-                cb->snd.una = ntoh32(hdr->ack);
                 queue_push(&cb->parent->backlog, cb, sizeof(*cb));
                 pthread_cond_signal(&cb->parent->cond);
+            } else {
+                tcp_tx(cb, ntoh32(hdr->ack), 0, TCP_FLG_RST, NULL, 0);
                 break;
             }
-            break;
         case TCP_CB_STATE_ESTABLISHED:
         case TCP_CB_STATE_FIN_WAIT1:
         case TCP_CB_STATE_FIN_WAIT2:

--- a/tcp.c
+++ b/tcp.c
@@ -308,6 +308,7 @@ tcp_incoming_event (struct tcp_cb *cb, struct tcp_hdr *hdr, size_t len) {
         case TCP_CB_STATE_SYN_RCVD:
             if (cb->snd.una <= ntoh32(hdr->ack) && ntoh32(hdr->ack) <= cb->snd.nxt) {
                 cb->state = TCP_CB_STATE_ESTABLISHED;
+                cb->snd.una = ntoh32(hdr->ack);
                 queue_push(&cb->parent->backlog, cb, sizeof(*cb));
                 pthread_cond_signal(&cb->parent->cond);
                 break;


### PR DESCRIPTION
自身が`LISTEN`の状態で, `SYN`を受け取ったときに, `SYN & ACK`を送信して, 再送用のキューに追加し, その後相手から`ACK`を受け取ってスリーハンドシェイクが完了しますが, このとき`cb->snd.una`の値が更新されないため, `SYN & ACK`を再送してしまうバグがあります。
本PRはこれを解決するものです。