### PR TITLE
tcp_txq_entry のバグ修正

### DIFF
--- a/tcp.c
+++ b/tcp.c
@@ -178,7 +178,7 @@ tcp_timer_thread (void *arg) {
             prev = NULL;
             txq = cb->txq.head;
             while (txq) {
-                if (txq->segment->seq >= hton32(cb->snd.una)) {
+                if (ntoh32(txq->segment->seq) >= cb->snd.una) {
                     if (timestamp.tv_sec - txq->timestamp.tv_sec > 3) {
                         peer = cb->peer.addr;
                         ip_tx(cb->iface, IP_PROTOCOL_TCP, (uint8_t *)txq->segment, txq->len, &peer);

--- a/tcp.c
+++ b/tcp.c
@@ -118,11 +118,16 @@ tcp_txq_add (struct tcp_cb *cb, struct tcp_hdr *hdr, size_t len) {
     txq->len = len;
     gettimeofday(&txq->timestamp, NULL);
     txq->next = NULL;
+
+    // set txq to next of tail entry
     if (cb->txq.head == NULL) {
-        cb->txq.head = cb->txq.tail = txq;
+        cb->txq.head = txq;
     } else {
         cb->txq.tail->next = txq;
     }
+    // update tail entry
+    cb->txq.tail = txq;
+
     return 0;
 }
 


### PR DESCRIPTION
## tcp_txq_add

https://github.com/pandax381/microps/commit/496004d4ba88f5bedf7de5caa7f3ed16294f360e では、`tcp_txq_add()` 関数のバグを修正しました。

`cb->txq.head` が `NULL` でない場合に `cb->txq.tail` が書き換えられないため、リストが崩壊します。

## tcp_timer_thread

https://github.com/pandax381/microps/commit/edba0b498210bc185878e981bbb744b5352d8752 では、`tcp_timer_thread()` 関数内での `txq` の扱いを改善しました。

まず既存の実装では `prev` が `NULL` の時、つまり先頭の要素がすでに ACK を受け取っていて txq のリストから削除する時に `cb->txq.tail` を誤って先頭の次の要素で書き換えているため、リストが崩壊します。

また、`tcp_txq_entry` のメモリ解放をしていませんでした。txq では全ての TCP パケットを複製しており、それらが全てリークしていくのでかなり大きなメモリリークになってしまいます。

メモリ解放の処理と `tcp_txq_entry` のリストからの削除処理を改善しました。

また、 https://github.com/pandax381/microps/pull/8/commits/608321bbb7365ca292c586c1e371239f1f4275c1 では、`seq` と `una` の比較をネットワークバイトオーダで行っていたのでホストバイトオーダで比較するように修正しました。