### PR TITLE
Accept port 0 at endp_pton()

### DIFF
--- a/ip.c
+++ b/ip.c
@@ -98,7 +98,7 @@ ip_endpoint_pton(const char *p, struct ip_endpoint *n)
         return -1;
     }
     port = strtol(sep+1, NULL, 10);
-    if (port <= 0 || port > UINT16_MAX) {
+    if (port < 0 || port > UINT16_MAX) {
         return -1;
     }
     n->port = hton16(port);


### PR DESCRIPTION
Although "0.0.0.0:0" is specified as ANY, if we return an error for port 0, n->port won't be set, and since it has not been zero-cleared, a random value will be used instead.